### PR TITLE
Fix missing import

### DIFF
--- a/dbt_cloud_plugin/dbt_cloud/dbt_cloud.py
+++ b/dbt_cloud_plugin/dbt_cloud/dbt_cloud.py
@@ -3,6 +3,8 @@ import json
 import requests
 import time
 
+from airflow.exceptions import AirflowException
+
 class DbtCloud(object):
     """
     Class for interacting with the dbt Cloud API


### PR DESCRIPTION
`dbt_cloud.py` uses `AirflowException` without importing it. This change
fixes this issue.